### PR TITLE
feat: update all kernel to 6.18.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.12.69
-arm64_abiname=6.12.69
-loong64_abiname=6.12.69
+amd64_abiname=6.18.19
+arm64_abiname=6.18.19
+loong64_abiname=6.18.19
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-latest (23.01.01.40) unstable; urgency=medium
+
+  * update all kernel to 6.18.19
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 18 Mar 2026 14:11:15 +0800
+
+
 linux-deepin-latest (23.01.01.39) unstable; urgency=medium
 
   * update all kernel to 6.12.69


### PR DESCRIPTION
Update kernel version to 6.18.19 for all supported architectures (amd64, arm64, loong64)

## Changes

- Update amd64_abiname from 6.12.69 to 6.18.19
- Update arm64_abiname from 6.12.69 to 6.18.19
- Update loong64_abiname from 6.12.69 to 6.18.19
- Update debian/changelog to version 23.01.01.40

## Influences

1. Test kernel boot on amd64 architecture
2. Test kernel boot on arm64 architecture
3. Test kernel boot on loong64 architecture
4. Verify kernel modules load correctly
5. Check compatibility with system services
6. Validate no regression in kernel functionality
7. Test hardware drivers compatibility
8. Verify system stability and performance