### PR TITLE
feat: update all kernel to 6.18.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.12.69
-arm64_abiname=6.12.69
-loong64_abiname=6.12.69
+amd64_abiname=6.18.19
+arm64_abiname=6.18.19
+loong64_abiname=6.18.19
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-latest (23.01.01.40) unstable; urgency=medium
+
+  * update all kernel to 6.18.19
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 18 Mar 2026 14:11:15 +0800
+
+
 linux-deepin-latest (23.01.01.39) unstable; urgency=medium
 
   * update all kernel to 6.12.69


### PR DESCRIPTION
Update kernel version to 6.18.19 for all supported architectures This includes amd64, arm64, and loong64 kernel packages Update abiname in Makefile for all architectures
Increment package version to 23.01.01.40

Changes:
- Update amd64_abiname from 6.12.69 to 6.18.19
- Update arm64_abiname from 6.12.69 to 6.18.19
- Update loong64_abiname from 6.12.69 to 6.18.19
- Update debian/changelog to version 23.01.01.40

Log: Update all kernel to version 6.18.19

Influence:
1. Test kernel boot on amd64 architecture
2. Test kernel boot on arm64 architecture
3. Test kernel boot on loong64 architecture
4. Verify kernel modules load correctly
5. Check compatibility with system services
6. Validate no regression in kernel functionality
7. Test hardware drivers compatibility
8. Verify system stability and performance

feat: 更新所有内核版本到 6.18.19

更新所有支持的架构的内核版本到 6.18.19
包括 amd64、arm64 和 loong64 内核包
更新 Makefile 中所有架构的 abiname
增加软件包版本到 23.01.01.40

变更:
- 将 amd64_abiname 从 6.12.69 更新到 6.18.19
- 将 arm64_abiname 从 6.12.69 更新到 6.18.19
- 将 loong64_abiname 从 6.12.69 更新到 6.18.19
- 更新 debian/changelog 到版本 23.01.01.40

Log: 更新所有内核到 6.18.19 版本

Influence:
1. 在 amd64 架构上测试内核启动
2. 在 arm64 架构上测试内核启动
3. 在 loong64 架构上测试内核启动
4. 验证内核模块正确加载
5. 检查与系统服务的兼容性
6. 验证内核功能无回归
7. 测试硬件驱动兼容性
8. 验证系统稳定性和性能

repo: linux-deepin-latest #feat/update-kernel-to-6.18.19