### PR TITLE
feat: update all kernel to 6.18.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.18.24
-arm64_abiname=6.18.24
-loong64_abiname=6.18.24
+amd64_abiname=6.18.25
+arm64_abiname=6.18.25
+loong64_abiname=6.18.25
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.18.25
-arm64_abiname=6.18.25
-loong64_abiname=6.18.25
+amd64_abiname=6.18.27
+arm64_abiname=6.18.27
+loong64_abiname=6.18.27
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-latest (23.01.01.42) unstable; urgency=medium
+
+  * update all kernel to 6.18.25
+
+ -- lichenggang <lichenggang@uniontech.com>  Thu, 30 Apr 2026 10:00:00 +0800
+
+
 linux-deepin-latest (23.01.01.41) unstable; urgency=medium
 
   * update all kernel to 6.18.24

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-latest (23.01.01.43) unstable; urgency=medium
+
+  * update all kernel to 6.18.27
+
+ -- lichenggang <lichenggang@uniontech.com>  Thu, 08 May 2026 10:00:00 +0800
+
+
 linux-deepin-latest (23.01.01.42) unstable; urgency=medium
 
   * update all kernel to 6.18.25


### PR DESCRIPTION
Update kernel version to 6.18.25 for all supported architectures This includes amd64, arm64, and loong64 kernel packages Update abiname in Makefile for all architectures
Increment package version to 23.01.01.42

Changes:
- Update amd64_abiname from 6.18.24 to 6.18.25
- Update arm64_abiname from 6.18.24 to 6.18.25
- Update loong64_abiname from 6.18.24 to 6.18.25
- Update debian/changelog to version 23.01.01.42

Log: Update all kernel to version 6.18.25

feat: 更新所有内核版本到 6.18.25

更新所有支持的架构的内核版本到 6.18.25
包括 amd64、arm64 和 loong64 内核包
更新 Makefile 中所有架构的 abiname
增加软件包版本到 23.01.01.42

变更:
- 将 amd64_abiname 从 6.18.24 更新到 6.18.25
- 将 arm64_abiname 从 6.18.24 更新到 6.18.25
- 将 loong64_abiname 从 6.18.24 更新到 6.18.25
- 更新 debian/changelog 到版本 23.01.01.42

Log: 更新所有内核到 6.18.25 版本

repo: linux-deepin-latest #feat/update-kernel-to-6.18.25