### PR TITLE
feat: update all kernel to 6.18.30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.18.27
-arm64_abiname=6.18.27
-loong64_abiname=6.18.27
+amd64_abiname=6.18.30
+arm64_abiname=6.18.30
+loong64_abiname=6.18.30
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-latest (23.01.01.44) unstable; urgency=medium
+
+  * update all kernel to 6.18.30
+
+ -- lichenggang <lichenggang@uniontech.com>  Thu, 15 May 2026 10:00:00 +0800
+
+
 linux-deepin-latest (23.01.01.43) unstable; urgency=medium
 
   * update all kernel to 6.18.27


### PR DESCRIPTION
Update kernel version to 6.18.30 for all supported architectures This includes amd64, arm64, and loong64 kernel packages Update abiname in Makefile for all architectures
Increment package version to 23.01.01.44

Log: Update all kernel to version 6.18.30

Influence:
1. Verify amd64 kernel package resolves to version 6.18.30
2. Verify arm64 kernel package resolves to version 6.18.30
3. Verify loong64 kernel package resolves to version 6.18.30
4. Confirm debian/changelog version bumped to 23.01.01.44

feat: 更新所有内核版本到 6.18.30

更新所有支持的架构的内核版本到 6.18.30
包括 amd64、arm64 和 loong64 内核包
更新 Makefile 中所有架构的 abiname
增加软件包版本到 23.01.01.44

Log: 更新所有内核到 6.18.30 版本

Influence:
1. 验证 amd64 内核包版本正确解析为 6.18.30
2. 验证 arm64 内核包版本正确解析为 6.18.30
3. 验证 loong64 内核包版本正确解析为 6.18.30
4. 确认 debian/changelog 版本已提升至 23.01.01.44