### PR TITLE
feat: update all kernel to 6.18.34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.18.30
-arm64_abiname=6.18.30
-loong64_abiname=6.18.30
+amd64_abiname=6.18.34
+arm64_abiname=6.18.34
+loong64_abiname=6.18.34
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-latest (23.01.01.45) unstable; urgency=medium
+
+  * update all kernel to 6.18.34
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 02 Jun 2026 10:00:00 +0800
+
+
 linux-deepin-latest (23.01.01.44) unstable; urgency=medium
 
   * update all kernel to 6.18.30


### PR DESCRIPTION
## Summary
- Update kernel version from 6.18.30 to 6.18.34 for all supported architectures (amd64, arm64, loong64)
- Update abiname in Makefile
- Increment package version to 23.01.01.45

## Test plan
1. Verify amd64 kernel package resolves to version 6.18.34
2. Verify arm64 kernel package resolves to version 6.18.34
3. Verify loong64 kernel package resolves to version 6.18.34
4. Confirm debian/changelog version bumped to 23.01.01.45

🤖 Generated with [Claude Code](https://claude.com/claude-code)