### PR TITLE
feat: update all kernel to 6.18.36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.18.34
-arm64_abiname=6.18.34
-loong64_abiname=6.18.34
+amd64_abiname=6.18.36
+arm64_abiname=6.18.36
+loong64_abiname=6.18.36
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-latest (23.01.01.46) unstable; urgency=medium
+
+  * update all kernel to 6.18.36
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 23 Jun 2026 10:00:00 +0800
+
+
 linux-deepin-latest (23.01.01.45) unstable; urgency=medium
 
   * update all kernel to 6.18.34


### PR DESCRIPTION
## 变更说明

更新内核版本到 6.18.36

### 变更内容
- 更新 Makefile 中 amd64、arm64、loong64 的 abiname 从 6.18.34 到 6.18.36
- 新增 debian/changelog 版本条目 23.01.01.46

### 影响范围
1. amd64 内核包版本更新为 6.18.36
2. arm64 内核包版本更新为 6.18.36  
3. loong64 内核包版本更新为 6.18.36

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>