### PR TITLE
feat: update all kernel to 6.18.38

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-amd64_abiname=6.18.36
-arm64_abiname=6.18.36
-loong64_abiname=6.18.36
+amd64_abiname=6.18.38
+arm64_abiname=6.18.38
+loong64_abiname=6.18.38
 ARCH_BUILD :=$(shell uname -m)
 all: build
 build:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+linux-deepin-latest (23.01.01.47) unstable; urgency=medium
+
+  * update all kernel to 6.18.38
+
+ -- lichenggang <lichenggang@uniontech.com>  Thu, 16 Jul 2026 10:00:00 +0800
+
+
 linux-deepin-latest (23.01.01.46) unstable; urgency=medium
 
   * update all kernel to 6.18.36


### PR DESCRIPTION
Update kernel version to 6.18.38 for all supported architectures This includes amd64, arm64, and loong64 kernel packages Update abiname in Makefile for all architectures
Increment package version to 23.01.01.47

Log: Update all kernel to version 6.18.38

Influence:
1. Verify amd64 kernel package resolves to version 6.18.38
2. Verify arm64 kernel package resolves to version 6.18.38
3. Verify loong64 kernel package resolves to version 6.18.38
4. Confirm debian/changelog version bumped to 23.01.01.47

feat: 更新所有内核版本到 6.18.38

更新所有支持的架构的内核版本到 6.18.38
包括 amd64、arm64 和 loong64 内核包
更新 Makefile 中所有架构的 abiname
增加软件包版本到 23.01.01.47

Log: 更新所有内核到 6.18.38 版本

Influence:
1. 验证 amd64 内核包版本正确解析为 6.18.38
2. 验证 arm64 内核包版本正确解析为 6.18.38
3. 验证 loong64 内核包版本正确解析为 6.18.38
4. 确认 debian/changelog 版本已提升至 23.01.01.47